### PR TITLE
replaced references to FitBit::Client with FitGem::Client

### DIFF
--- a/spec/models/fitbit/activity_spec.rb
+++ b/spec/models/fitbit/activity_spec.rb
@@ -56,7 +56,7 @@ describe Fitbit::Activity do
         @user.stub(:linked?).and_return(true)
       end
 
-      it 'fetches the data using the Fitbit::Client instance on the user' do
+      it 'fetches the data using the FitGem::Client instance on the user' do
         client = double('Fitgem::Client')
         client.should_receive(:activities_on_date).with('today').and_return(@data)
         @user.should_receive(:fitbit_data).and_return(client)
@@ -84,7 +84,7 @@ describe Fitbit::Activity do
         @user.stub(:linked?).and_return(false)
       end
 
-      it 'does not invoke the Fitbit::Client instance on the user' do
+      it 'does not invoke the FitGem::Client instance on the user' do
         @user.should_not_receive(:fitbit_data)
         Fitbit::Activity.fetch_all_on_date(@user, 'today')
       end
@@ -102,7 +102,7 @@ describe Fitbit::Activity do
     end
 
     context 'called with a logged-in user' do
-      it 'calls log_activity on the Fitbit::Client instance on the user' do
+      it 'calls log_activity on the FitGem::Client instance on the user' do
         @user.stub(:linked?).and_return(true)
         client = double('Fitgem::Client')
         client.should_receive(:log_activity)
@@ -112,7 +112,7 @@ describe Fitbit::Activity do
     end
 
     context 'called with a non logged-in user' do
-      it 'does not call log_activity on the Fitbit::Client instance on the user' do
+      it 'does not call log_activity on the FitGem::Client instance on the user' do
         @user.stub(:linked?).and_return(false)
         @user.should_not_receive(:fitbit_data)
         Fitbit::Activity.log_activity(@user, { 'name' => 'Walking' })

--- a/spec/models/fitbit/body_measurements_spec.rb
+++ b/spec/models/fitbit/body_measurements_spec.rb
@@ -38,14 +38,14 @@ describe Fitbit::BodyMeasurements do
         @user.stub(:linked?).and_return(true)
       end
 
-      it 'calls the body_measurements method of Fitbit::Client on the user instance' do
-        client = double('Fitbit::Client')
+      it 'calls the body_measurements method of FitGem::Client on the user instance' do
+        client = double('FitGem::Client')
         client.should_receive(:body_measurements_on_date).with('today').and_return(@data)
         @user.should_receive(:fitbit_data).and_return(client)
         Fitbit::BodyMeasurements.new(@user)
       end
 
-      it 'applies the user\'s unit measurements to the values returned by Fitbit::Client' do
+      it 'applies the user\'s unit measurements to the values returned by FitGem::Client' do
         @user.stub_chain(:fitbit_data, :body_measurements_on_date).and_return(@data)
         measurements = Fitbit::BodyMeasurements.new(@user)
 
@@ -64,7 +64,7 @@ describe Fitbit::BodyMeasurements do
     end
 
     context 'called with a non logged-in user' do
-      it 'does not call the body_measurements method of Fitbit::Client on te user instance' do
+      it 'does not call the body_measurements method of FitGem::Client on te user instance' do
         @user.stub(:linked?).and_return(false)
         @user.should_not_receive(:fitbit_data)
         Fitbit::BodyMeasurements.new(@user)


### PR DESCRIPTION
I removed references to FitBit::Client and replaced with FitGem::Client. They were only in the specs. I noticed this because in the FitGem readme (not client) there is a link to http://www.rubydoc.info/gems/fitbit/0.2.0/frames which uses FitBit::Client in the code example. I'd like to create a pull request for that as well and point that link to http://fitbitclient.com/guide/playing-with-the-fitgem-api or http://fitbitclient.com/guide/fitgem-on-rails and add some code examples there. 

We used your gem during a hackathon last night and placed, so thanks for this!