### PR TITLE
Update gist urls to githubusercontent.com

### DIFF
--- a/app/views/guide/using_fitgem.html.erb
+++ b/app/views/guide/using_fitgem.html.erb
@@ -37,7 +37,7 @@ Successfully installed fitgem-0.6.1
     <code>consumer_secret</code> you received from the <a href="https://wiki.fitbit.com/display/API/Fitbit+API">Fitbit API</a>
     site.
 </p>
-<pre class="prettyprint lang-bash">fitgem-sandbox $ curl https://gist.github.com/whazzmaster/5322902/raw/aa4293a9eb288d2096840a05b35a1ecf829defc1/.fitgem.yml > .fitgem.yml</pre>
+<pre class="prettyprint lang-bash">fitgem-sandbox $ curl https://gist.githubusercontent.com/whazzmaster/5322902/raw/aa4293a9eb288d2096840a05b35a1ecf829defc1/.fitgem.yml > .fitgem.yml</pre>
 <script src="https://gist.github.com/whazzmaster/5322902.js?file=.fitgem.yml"></script>
 
 <p>
@@ -49,7 +49,7 @@ Successfully installed fitgem-0.6.1
 <h3>Step 3: Login and Get OAuth Tokens</h3>
 <p>Copy or download the <code>test-fitgem.rb</code> script and enable it for execution.</p>
 
-<pre class="prettyprint">fitgem-sandbox $ curl https://gist.github.com/whazzmaster/5322902/raw/4439e2d577567d280856a2d77cef7b824a851cd1/test-fitgem.rb > test-fitgem.rb
+<pre class="prettyprint">fitgem-sandbox $ curl https://gist.githubusercontent.com/whazzmaster/5322902/raw/4439e2d577567d280856a2d77cef7b824a851cd1/test-fitgem.rb > test-fitgem.rb
 fitgem-sandbox $ chmod +x test-fitgem.rb</pre>
 
 <script src="https://gist.github.com/whazzmaster/5322902.js?file=test-fitgem.rb"></script>


### PR DESCRIPTION
Looks like github issues a redirect from gist.github.com ->
gist.githubusercontent.com, which curl does not follow by default. This
results in no file being downloaded when you copy/paste the curl
commands in this doc.

An alternative would be to add the -L flag to curl to follow redirects.

Seems like the change was introduced here:
https://developer.github.com/changes/2014-04-25-user-content-security/
